### PR TITLE
fixed build with latest toolset

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -34,6 +34,7 @@ build() {
   cd ${srcdir}/dump1090
   git fetch --all
   git reset --hard origin/master
+  patch -p0 -i ../../dump1090-patch
   make DUMP1090_VERSION=$(git describe --tags | sed 's/-.*//') 
 }
 

--- a/dump1090-patch
+++ b/dump1090-patch
@@ -1,0 +1,11 @@
+--- Makefile~	2024-06-17 22:33:52.000000000 -0400
++++ Makefile	2024-06-17 22:35:52.157679893 -0400
+@@ -3,7 +3,7 @@
+ DUMP1090_VERSION ?= unknown
+ 
+ CFLAGS ?= -O3 -g
+-DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -Wformat-signedness -W
++DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations  -Wformat-signedness -W
+ DUMP1090_CPPFLAGS := -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
+ 
+ LIBS = -lpthread -lm


### PR DESCRIPTION
Latest compilers on arch with most recent code tree generate a warning and `-Werror` will kill the build. 